### PR TITLE
remove keystone client dependency

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,5 +8,4 @@ nosehtmloutput
 sphinx>=1.1.2,<1.2
 mock>=0.8.0
 python-swiftclient
-python-keystoneclient
 prettytable


### PR DESCRIPTION
this dependency is no longer needed

Signed-off-by: Thiago da Silva thiago@redhat.com
