### PR TITLE
fix issue with GET on large object (icehouse-backport)

### DIFF
--- a/gluster/swift/obj/diskfile.py
+++ b/gluster/swift/obj/diskfile.py
@@ -509,7 +509,7 @@ class DiskFileReader(object):
                     bytes_read += len(chunk)
                     diff = bytes_read - dropped_cache
                     if diff > (1024 * 1024):
-                        self._drop_cache(self._fd, dropped_cache, diff)
+                        self._drop_cache(dropped_cache, diff)
                         dropped_cache = bytes_read
                     yield chunk
                     if self._iter_hook:

--- a/test/functional/gluster_swift_tests.py
+++ b/test/functional/gluster_swift_tests.py
@@ -58,6 +58,14 @@ class TestFile(Base):
         data_read = file.read()
         self.assertEquals(data,data_read)
 
+    def test_PUT_large_object(self):
+        file_item = self.env.container.file(Utils.create_name())
+        data = File.random_data(1024 * 1024 * 2)
+        self.assertTrue(file_item.write(data))
+        self.assert_status(201)
+        self.assertTrue(data == file_item.read())
+        self.assert_status(200)
+
     def testInvalidHeadersPUT(self):
         #TODO: Although we now support x-delete-at and x-delete-after,
         #retained this test case as we may add some other header to


### PR DESCRIPTION
This is a manual backport of:
https://github.com/swiftonfile/swiftonfile/pull/16

Signed-off-by: Prashanth Pai ppai@redhat.com
